### PR TITLE
Make values parameter in OneOf to be variadic

### DIFF
--- a/validate/order.go
+++ b/validate/order.go
@@ -45,7 +45,7 @@ func NotEqualField[T comparable](target *T, field *T) Field {
 }
 
 // OneOf validates if target is one of values.
-func OneOf[T comparable](target *T, values []T) Field {
+func OneOf[T comparable](target *T, values ...T) Field {
 	return Field{
 		Valid:   target != nil && slices.Contains(values, *target),
 		Message: fmt.Sprintf("{0} should be one of %v", values),

--- a/validate/order_test.go
+++ b/validate/order_test.go
@@ -141,7 +141,7 @@ func TestOneOf(t *testing.T) {
 			t.Parallel()
 
 			// Act
-			result := validate.OneOf(test.target, test.values)
+			result := validate.OneOf(test.target, test.values...)
 
 			// Assert
 			expectedResult := validate.Field{


### PR DESCRIPTION
This PR alters the signature of `validate.OneOf` function so that its second parameter, `values`, becomes a variadic parameter instead of a flat slice type.

This aims to improve the experience of restraining values.